### PR TITLE
add required locale and storefront parameters as configurable settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Prepare the client for connecting to Kaufland with your client key and secret ke
 $kaufland = new \ProductFlow\KauflandPhpClient\Kaufland();
 $kaufland->setClientKey($clientkey);
 $kaufland->setSecretKey($secretkey);
+
+// optional, if locale differs from "de_DE"
+$kaufland->setLocale((new Locale())->set(Locale::CS_CZ));
+// optional, if storefront differs from "de"
+$kaufland->setStorefront((new Storefront())->set(Storefront::CZ));
 ```
 
 ## Get all order-units

--- a/src/Kaufland.php
+++ b/src/Kaufland.php
@@ -21,6 +21,8 @@ use ProductFlow\KauflandPhpClient\Resources\Ticket;
 use ProductFlow\KauflandPhpClient\Resources\TicketMessage;
 use ProductFlow\KauflandPhpClient\Resources\Unit;
 use ProductFlow\KauflandPhpClient\Resources\Warehouse;
+use ProductFlow\KauflandPhpClient\Options\Locale;
+use ProductFlow\KauflandPhpClient\Options\Storefront;
 
 /**
  * Class Kaufland
@@ -39,6 +41,10 @@ class Kaufland
     protected string $secret_key;
 
     protected string $user_agent = 'Kaufland-php-client/V1';
+
+    protected Locale $locale;
+
+    protected Storefront $storefront;
 
     /**
      * @var Connection
@@ -65,6 +71,20 @@ class Kaufland
         return $this;
     }
 
+    public function setLocale(Locale $locale): static
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
+    public function setStorefront(Storefront $storefront): static
+    {
+        $this->storefront = $storefront;
+
+        return $this;
+    }
+
     /**
      * @param string $user_agent
      */
@@ -82,7 +102,13 @@ class Kaufland
     private function getConnection(): Connection
     {
         if ($this->connection == null) {
-            $this->connection = new Connection($this->client_key, $this->secret_key, $this->user_agent);
+            $this->connection = new Connection(
+                $this->client_key,
+                $this->secret_key,
+                $this->user_agent,
+                $this->locale ?? new Locale(),
+                $this->storefront ?? new Storefront()
+            );
         }
         return $this->connection;
     }

--- a/src/Options/Locale.php
+++ b/src/Options/Locale.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace ProductFlow\KauflandPhpClient\Options;
+
+use ProductFlow\KauflandPhpClient\Exceptions\KauflandException;
+
+class Locale
+{
+    public const DE_DE = 'de-DE';
+
+    public const CS_CZ = 'cs-CZ';
+
+    public const SK_SK = 'sk-SK';
+
+    protected $current;
+
+    public function __construct()
+    {
+        $this->current = self::DE_DE;
+    }
+
+    public function __toString()
+    {
+        return $this->current;
+    }
+
+    public function set(string $locale): self
+    {
+        if (!$this->inList($locale)) {
+            throw new KauflandException($locale . ' is not available in locales list');
+        }
+
+        $this->current = $locale;
+
+        return $this;
+    }
+
+    public function inList(string $locale)
+    {
+        return in_array(
+            $locale,
+            [
+                self::DE_DE,
+                self::CS_CZ,
+                self::SK_SK
+            ]
+        );
+    }
+
+    public static function getQueryParameterName(): string
+    {
+        return 'locale';
+    }
+}

--- a/src/Options/Storefront.php
+++ b/src/Options/Storefront.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace ProductFlow\KauflandPhpClient\Options;
+
+use ProductFlow\KauflandPhpClient\Exceptions\KauflandException;
+
+class Storefront
+{
+    public const DE = 'de';
+
+    public const CZ = 'cz';
+
+    public const SK = 'SK';
+
+    protected $current;
+
+    public function __construct()
+    {
+        $this->current = self::DE;
+    }
+
+    public function __toString()
+    {
+        return $this->current;
+    }
+
+    public function set(string $storefront): self
+    {
+        if (!$this->inList($storefront)) {
+            throw new KauflandException($storefront . ' is not available in storefronts list');
+        }
+
+        $this->current = $storefront;
+
+        return $this;
+    }
+
+    public function inList(string $storefront)
+    {
+        return in_array(
+            $storefront,
+            [
+                self::DE,
+                self::CZ,
+                self::SK
+            ]
+        );
+    }
+
+    public static function getQueryParameterName(): string
+    {
+        return 'storefront';
+    }
+}


### PR DESCRIPTION
As described in https://sellerapi.kaufland.com/?page=rest-api ("Storefronts and Locales"), most API requests require the parameters "locale" and "storefront". With these changes, the two parameters can be set during initialisation. Without this, the default values "de-DE" and "de" are assumed.