### PR TITLE
make HTTP client exchangeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Prepare the client for connecting to Kaufland with your client key and secret ke
 $kaufland = new \ProductFlow\KauflandPhpClient\Kaufland();
 $kaufland->setClientKey($clientkey);
 $kaufland->setSecretKey($secretkey);
+
+// optional, change default client by configured one
+$kaufland->setClient(new Client(...))
 ```
 
 ## Get all order-units

--- a/src/Kaufland.php
+++ b/src/Kaufland.php
@@ -2,6 +2,7 @@
 
 namespace ProductFlow\KauflandPhpClient;
 
+use GuzzleHttp\ClientInterface;
 use ProductFlow\KauflandPhpClient\Resources\Attribute;
 use ProductFlow\KauflandPhpClient\Resources\Category;
 use ProductFlow\KauflandPhpClient\Resources\ImportFile;
@@ -38,7 +39,6 @@ class Kaufland
      */
     protected string $secret_key;
 
-    protected string $user_agent = 'Kaufland-php-client/V1';
 
     /**
      * @var Connection
@@ -66,11 +66,11 @@ class Kaufland
     }
 
     /**
-     * @param string $user_agent
+     * @param ClientInterface $client
      */
-    public function setUserAgent(string $user_agent): static
+    public function setClient(ClientInterface $client): static
     {
-        $this->user_agent = $user_agent;
+        $this->getConnection()->setClient($client);
 
         return $this;
     }
@@ -82,7 +82,7 @@ class Kaufland
     private function getConnection(): Connection
     {
         if ($this->connection == null) {
-            $this->connection = new Connection($this->client_key, $this->secret_key, $this->user_agent);
+            $this->connection = new Connection($this->client_key, $this->secret_key);
         }
         return $this->connection;
     }


### PR DESCRIPTION
The Guzzle client can be configured in many ways (e.g. with middlewares for debugging or logging). For this, however, the internal client must be exchangeable.

The exchange of the User Agent and URL variables to constants enables the client configuration also outside the connection class.