### PR TITLE
change url query encoding

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -78,7 +78,7 @@ class Connection
             $timestamp = time();
 
             if (! empty($options['query'])) {
-                $query = '?' . http_build_query($options['query'], null, '&');
+                $query = '?' . http_build_query($options['query'], '', '&', PHP_QUERY_RFC3986);
             }
 
             if (! empty($options['body'])) {


### PR DESCRIPTION
because of mismatched signature check, if parameters contains space characters like in date time parameters in https://sellerapi.kaufland.com/?page=endpoints#/Orders/GetOrders